### PR TITLE
Changed tarball names to amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,10 @@ start: deps
 package:
 	rm -rf bin/dist/
 	mkdir -p bin/dist/
-	cd bin/ && tar -zcf dist/orbit-darwin-x64.tar.gz Orbit-darwin-x64/
-	cd bin/ && tar -zcf dist/orbit-linux-x64.tar.gz Orbit-linux-x64/
+	# Note: The `master` is hardcoded to match https://github.com/ipfs/distributions/blob/master/site/public/_js/_platform.js#L27
+	# This should be changed later
+	cd bin/ && tar -zcf dist/orbit_master_darwin-amd64.tar.gz Orbit-darwin-x64/
+	cd bin/ && tar -zcf dist/orbit_master_linux-amd64.tar.gz Orbit-linux-x64/
 	@echo "Distribution packages are in: bin/dist/"
 
 dist: package

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ make build
 make dist
 ```
 
-*This will create `bin/dist/orbit-darwin-x64.tar.gz` and `bin/dist/orbit-linux-x64.tar.gz` and add them to IPFS.*
+*This will create `bin/dist/orbit_master_darwin-amd64.tar.gz` and `bin/dist/orbit_master_linux-amd64.tar.gz` and add them to IPFS.*
+
+Note: electron names the folders after the arch, and uses the `x64` nomenclature instead of `amd64`. They are the same thing; we create tarballs with `amd64` to match the golang distributions on [ipfs/distributions](https://github.com/ipfs/distributions).
 
 ## Contributing
 


### PR DESCRIPTION
This matches the golang builds on ipfs/distributions, and is part of changes necessary for https://github.com/ipfs/distributions/pull/134