### PR TITLE
Updating gcc version in README for Issue #202

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ See also:
 - [npm v3.x.x](https://npmjs.com)
 - g++, gcc, make, python 2
 
+**NOTE:** Orbit requires a newer version of gcc to compile crypto libraries. `gcc 6.2.1` has been tested successfully, `gcc 4.9.2` is known to fail at runtime.
+
+Standard `gcc` versions for various distros are listed below:
+Arch Linux `gcc 6.2.1`
+Debian Stretch `gcc 6.2.1`
+Debian Jessie `gcc 4.9`
+RHEL7 `gcc 4.8`
+Ubuntu 16.04 LTS `gcc 5.3+`
+OSX Uses `CLANG`, not `gcc`. Verification needed.
+
 ### Get the source code
 
 ```


### PR DESCRIPTION
This is to reflect gcc minimum version requirements discovered in [Issue 202](https://github.com/orbitdb/orbit/issues/202) of the original orbit repo. I've verified the issue persists in current version of orbit-web